### PR TITLE
unlock dependencies for deduplication and easier vulnerability mitigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "SAML 2.0 and 1.1 token parser for Node.js",
   "main": "./lib/index.js",
   "dependencies": {
-    "lodash": "4.17.11",
-    "thumbprint": "0.0.1",
-    "xml-crypto": "0.8.1",
-    "xml2js": "0.4.4",
-    "xmldom": "0.1.19"
+    "lodash": "^4.17.11",
+    "thumbprint": "^0.0.1",
+    "xml-crypto": "^0.8.1",
+    "xml2js": "^0.4.4",
+    "xmldom": "^0.1.19"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "test": "npm run jshint && mocha -R spec test",
     "jshint": "jshint lib/*.js"
   },
-  "author": "Leandro Boffi (me@leandrob.com)", 
+  "author": "Leandro Boffi (me@leandrob.com)",
   "contributors":[
     {
       "name": "Phillip Son",


### PR DESCRIPTION
If we use the caret for specifying dependency versions npm can deduplicate packages more often.
Additionally, fixing npm audit vulnerabilities will be possible without "Manual Review" more often without having to release a new version of saml20 each time.